### PR TITLE
Remove stray print statement

### DIFF
--- a/ifcfg/__init__.py
+++ b/ifcfg/__init__.py
@@ -38,7 +38,6 @@ def get_parser(**kw):
                 from .parser import Linux2Parser as LinuxParser
             else:
                 from .parser import LinuxParser
-            print LinuxParser
             parser = LinuxParser(ifconfig=ifconfig)
         elif distro in ['Darwin', 'MacOSX']:
             from .parser import MacOSXParser


### PR DESCRIPTION
The `LinuxParser` object was printed at startup. Maybe a leftover debug statement?